### PR TITLE
auth: make it possible to use in-memory keys

### DIFF
--- a/client.go
+++ b/client.go
@@ -67,6 +67,7 @@ type NativeClient struct {
 type Auth struct {
 	Passwords []string // Passwords is a slice of passwords to submit to the server
 	Keys      []string // Keys is a slice of filenames of keys to try
+	RawKeys   [][]byte // RawKeys is a slice of private keys to try
 }
 
 // NewNativeClient creates a new Client using the golang ssh library
@@ -95,12 +96,17 @@ func NewNativeConfig(user, clientVersion string, auth *Auth, hostKeyCallback ssh
 	)
 
 	if auth != nil {
+		rawKeys := auth.RawKeys
 		for _, k := range auth.Keys {
 			key, err := ioutil.ReadFile(k)
 			if err != nil {
 				return ssh.ClientConfig{}, err
 			}
 
+			rawKeys = append(rawKeys, key)
+		}
+
+		for _, key := range rawKeys {
 			privateKey, err := ssh.ParsePrivateKey(key)
 			if err != nil {
 				return ssh.ClientConfig{}, err


### PR DESCRIPTION
Hey @nanobox-io!

Not sure whether this fork is maintained anymore, I find it more handy than using docker/machine/libmachine/ssh directly, as one does not need to pull whole docker/machine dependency tree into project.

I've added a number of improvements for this package (5 in total) in my fork (https://github.com/rjeczalik/golang-ssh) and was wondering if my patches would be accepted upstream - here.

This is first of said patches - it adds a way to use a raw private key while creating a Client.