### PR TITLE
support SSH certificate authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,7 @@ func main() {
 }
 
 func connect() error {
-	nanPass := ssh.Auth{Passwords: []string{"pass"}}
-	client, err := ssh.NewNativeClient("user", "localhost", "SSH-2.0-MyCustomClient-1.0", 2222, &nanPass, nil)
+    client, err := ssh.NewNativeClient("user", "localhost", "SSH-2.0-MyCustomClient-1.0", 2222, nil, ssh.AuthPassword("pass"))
 	if err != nil {
 		return fmt.Errorf("Failed to create new client - %s", err)
 	}

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,41 @@
+package ssh
+
+import (
+	"strconv"
+	"strings"
+
+	"golang.org/x/crypto/ssh"
+)
+
+// ExitError is a conveniance wrapper for (crypto/ssh).ExitError type.
+type ExitError struct {
+	Err      error
+	ExitCode int
+}
+
+// Error implements error interface.
+func (err *ExitError) Error() string {
+	return err.Err.Error()
+}
+
+// Cause implements errors.Causer interface.
+func (err *ExitError) Cause() error {
+	return err.Err
+}
+
+func wrapError(err error) error {
+	switch err := err.(type) {
+	case *ssh.ExitError:
+		e, s := &ExitError{Err: err, ExitCode: -1}, strings.TrimSpace(err.Error())
+		// Best-effort attempt to parse exit code from os/exec error string,
+		// like "Process exited with status 127".
+		if i := strings.LastIndex(s, " "); i != -1 {
+			if n, err := strconv.Atoi(s[i+1:]); err == nil {
+				e.ExitCode = n
+			}
+		}
+		return e
+	default:
+		return err
+	}
+}


### PR DESCRIPTION
Some little refactoring and code to support SSH certificates authentication. Besides, the caller can now pass any ssh.AuthMethod for more flexibility.